### PR TITLE
fix: fix the react error by updating SideBar.js to use React Router v6 syntax

### DIFF
--- a/templates/src/components/SideBar.js
+++ b/templates/src/components/SideBar.js
@@ -15,19 +15,38 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 
 function SideBar () {
-  return (
-    <ul className="SideNav">
-      <li className="SideNav-item">
-        <NavLink className="SideNav-itemLink" activeClassName="is-selected" aria-current="page" exact to="/">Home</NavLink>
-      </li>
-      <li className="SideNav-item">
-        <NavLink className="SideNav-itemLink" activeClassName="is-selected" aria-current="page" to="/actions">Your App Actions</NavLink>
-      </li>
-      <li className="SideNav-item">
-        <NavLink className="SideNav-itemLink" activeClassName="is-selected" aria-current="page" to="/about">About App Builder</NavLink>
-      </li>
-    </ul>
-  )
+    return (
+        <ul className="SideNav">
+            <li className="SideNav-item">
+                <NavLink
+                    className={({ isActive }) => `SideNav-itemLink ${isActive ? 'is-selected' : ''}`}
+                    aria-current="page"
+                    end
+                    to="/"
+                >
+                    Home
+                </NavLink>
+            </li>
+            <li className="SideNav-item">
+                <NavLink
+                    className={({ isActive }) => `SideNav-itemLink ${isActive ? 'is-selected' : ''}`}
+                    aria-current="page"
+                    to="/actions"
+                >
+                    Your App Actions
+                </NavLink>
+            </li>
+            <li className="SideNav-item">
+                <NavLink
+                    className={({ isActive }) => `SideNav-itemLink ${isActive ? 'is-selected' : ''}`}
+                    aria-current="page"
+                    to="/about"
+                >
+                    About App Builder
+                </NavLink>
+            </li>
+        </ul>
+    )
 }
 
 export default SideBar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the SideBar.js template to use React Router v6 compatible syntax

## Related Issue
 Closes [ACNA-3704](https://jira.corp.adobe.com/browse/ACNA-3704)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Currently the SideBar.js template is using deprecated React Router props that cause error messages when  the user navigate to the url after `aio app run`. The reasons being
(i) `activeClassName="is-selected"` - deprecated in React Router v6
(ii) `exact` -this boolean attribute is no longer supported in v6
Hence these errors were appearing when the users navigate to the application

## How Has This Been Tested?

Directly made the changes in my local App builder app and re ran `aio app run `and  verified that no errors were showing up while navigating between routes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
